### PR TITLE
fix/CameraZoom

### DIFF
--- a/Source/Camera/CameraController.cs
+++ b/Source/Camera/CameraController.cs
@@ -94,8 +94,10 @@ public partial class CameraController : Node3D
 		_zoomDesired.Z = _zoomLevel * ZoomStepSize + _zoomOffset;
 
 		_zoomActual = _zoomActual.Lerp(_zoomDesired, 0.2f);
-		
+
 		if (!_zoomDesired.IsEqualApprox(_zoomActual))
-			_camera.GlobalPosition = _zoomActual;
+		{
+			_camera.Position = _zoomActual;
+		}
 	}
 }

--- a/Source/GOAP/Models/GoapResourceType.cs.uid
+++ b/Source/GOAP/Models/GoapResourceType.cs.uid
@@ -1,0 +1,1 @@
+uid://b545pfpbiq01v

--- a/Source/GOAP/Models/IGoapItem.cs.uid
+++ b/Source/GOAP/Models/IGoapItem.cs.uid
@@ -1,0 +1,1 @@
+uid://bvys7oplinoib

--- a/Source/World/WorldReadyEvent.cs.uid
+++ b/Source/World/WorldReadyEvent.cs.uid
@@ -1,0 +1,1 @@
+uid://dsjhxpp4s6gbc


### PR DESCRIPTION
Fixed zoom to be local position instead of global. Node3D -> Camera3D means Node3D is responsible for global movement and the camera is responsible for zoom which is done through position modifying, which means local position modifying on the camera was intended